### PR TITLE
Don't set the current bid amount if the player doesn't have sufficient funds.

### DIFF
--- a/src/com/flobi/floAuction/AuctionBid.java
+++ b/src/com/flobi/floAuction/AuctionBid.java
@@ -1,12 +1,11 @@
 package com.flobi.floAuction;
 
-import java.util.Map;
-
+import com.flobi.utility.functions;
+import com.flobi.utility.items;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import com.flobi.utility.functions;
-import com.flobi.utility.items;
+import java.util.Map;
 
 public class AuctionBid {
 	private Auction auction;
@@ -171,10 +170,15 @@ public class AuctionBid {
 	private Boolean parseArgBid() {
 		if (args.length > 0) {
 			if (!args[0].isEmpty() && args[0].matches(floAuction.decimalRegex)) {
-				bidAmount = functions.getSafeMoney(Double.parseDouble(args[0]));
+				long bidAmount = functions.getSafeMoney(Double.parseDouble(args[0]));
 				if (bidAmount == 0) {
 					error = "parse-error-invalid-bid";
 					return false;
+				} else if (!functions.hasMoney(bidderName, bidAmount)) {
+					error = "bid-fail-cant-allocate-funds";
+					return false;
+				} else {
+					this.bidAmount = bidAmount;
 				}
 			} else {
 				error = "parse-error-invalid-bid";

--- a/src/com/flobi/floAuction/MetricsLite.java
+++ b/src/com/flobi/floAuction/MetricsLite.java
@@ -284,7 +284,7 @@ public class MetricsLite {
         boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = description.getVersion();
         String serverVersion = Bukkit.getVersion();
-        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java
 

--- a/src/com/flobi/floAuction/floAuction.java
+++ b/src/com/flobi/floAuction/floAuction.java
@@ -1403,9 +1403,9 @@ public class floAuction extends JavaPlugin {
     
     public static void broadcastMessage(String message) {
 
-    	Player[] onlinePlayers = server.getOnlinePlayers();
+    	//Player[] onlinePlayers = server.getOnlinePlayers();
     	
-    	for (Player player : onlinePlayers) {
+    	for (Player player : server.getOnlinePlayers()) {
         	if (voluntarilyDisabledUsers.indexOf(player.getName()) == -1 && Participant.checkLocation(player.getName())) {
         		player.sendMessage(message);
     		}

--- a/src/com/flobi/utility/functions.java
+++ b/src/com/flobi/utility/functions.java
@@ -1,10 +1,9 @@
 package com.flobi.utility;
 
-import java.text.DecimalFormat;
-
+import com.flobi.floAuction.floAuction;
 import net.milkbowl.vault.economy.EconomyResponse;
 
-import com.flobi.floAuction.floAuction;
+import java.text.DecimalFormat;
 
 public class functions {
 
@@ -140,7 +139,11 @@ public class functions {
 		if (!floAuction.econ.isEnabled()) return "-";
 		return floAuction.econ.format(unsafeMoney);
 	}
-	
+
+	public static boolean hasMoney(String playerName, double money) {
+		return floAuction.econ.has(playerName, money);
+	}
+
 	public static boolean withdrawPlayer(String playerName, long safeMoney) {
 		return withdrawPlayer(playerName, getUnsafeMoney(safeMoney));
 	}


### PR DESCRIPTION
This fixes an issue with sealed auctions where the sealed auction would store the bid as a previous bid and increment the players previousSealedReserve. This caused the plugin to think that the player can raise their sealed bid (due to the difference between the previousSealedReserve) to ungodly sums of money and was allowing money to be generated from thin air.
